### PR TITLE
Easier to use as a library and Z Hop on retraction

### DIFF
--- a/data/option.go
+++ b/data/option.go
@@ -135,7 +135,7 @@ func NewGCodeHunk(rows []string) GCodeHunk {
 	return GCodeHunk{GCodeLines: rows}
 }
 
-// GetInstructionCode parses the provided strings for retrieve the first part of the line 
+// GetInstructionCode parses the provided strings for retrieve the first part of the line
 // and creates an array of ones that are M or G codes.
 func (gch GCodeHunk) GetInstructionCode() []string {
 	var codes []string
@@ -271,6 +271,9 @@ type FilamentOptions struct {
 
 	// RetractionLength is the amount to retract in millimeter.
 	RetractionLength Millimeter
+
+	// RetractionZHop is the amount to lift head when retracting in millimeter.
+	RetractionZHop Millimeter
 
 	// Primary (fan 0) speed, at given layers
 	FanSpeed FanSpeedOptions
@@ -429,6 +432,7 @@ func DefaultOptions() Options {
 			InitialTemperatureLayerCount: 3,
 			RetractionSpeed:              30,
 			RetractionLength:             Millimeter(2),
+			RetractionZHop:               0,
 			FanSpeed:                     NewDefaultFanSpeedOptions(),
 			ExtrusionMultiplier:          100,
 		},

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -18,49 +18,49 @@ func (f face) Points() [3]data.MicroVec3 {
 	return f.vectors
 }
 
-type model struct {
+type Model struct {
 	faces []data.Face
 }
 
-func (m *model) SetName(name string) {
+func (m *Model) SetName(name string) {
 	// not used yet
 	return
 }
 
-func (m *model) SetBinaryHeader(header []byte) {
+func (m *Model) SetBinaryHeader(header []byte) {
 	// not used yet
 	return
 }
 
-func (m *model) SetASCII(isASCII bool) {
+func (m *Model) SetASCII(isASCII bool) {
 	// not used yet
 	return
 }
 
-func (m *model) SetTriangleCount(n uint32) {
+func (m *Model) SetTriangleCount(n uint32) {
 	// not used yet
 	return
 }
 
-func (m *model) AppendTriangle(t stl.Triangle) {
+func (m *Model) AppendTriangle(t stl.Triangle) {
 	m.faces = append(m.faces, stlTriangleToFace(t))
 }
 
 func newModel(faces []data.Face) data.Model {
-	return &model{
+	return &Model{
 		faces: faces,
 	}
 }
 
-func (m model) FaceCount() int {
+func (m Model) FaceCount() int {
 	return len(m.faces)
 }
 
-func (m model) Face(index int) data.Face {
+func (m Model) Face(index int) data.Face {
 	return m.faces[index]
 }
 
-func (m model) Min() data.MicroVec3 {
+func (m Model) Min() data.MicroVec3 {
 	ret := m.faces[0].Points()[0].Copy()
 
 	for _, face := range m.faces {
@@ -82,7 +82,7 @@ func (m model) Min() data.MicroVec3 {
 	return ret
 }
 
-func (m model) Max() data.MicroVec3 {
+func (m Model) Max() data.MicroVec3 {
 	ret := m.faces[0].Points()[0].Copy()
 
 	for _, face := range m.faces {
@@ -112,7 +112,7 @@ func Reader(options *data.Options) handler.ModelReader {
 }
 
 func (r reader) Read(filename string) (data.Model, error) {
-	model := &model{}
+	model := &Model{}
 	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
 		return model, os.ErrNotExist
 	}


### PR DESCRIPTION
In this pull request I made the "model" struct public, to be easier to write custom readers and writers without copying too much from the original library's code. For instance, I wrote my own reader and writer for reading and wrinting in memory STL and GCode. I think I will provide more updates on this topic in the future.

Then I added support for lifting head when retraction happens, because I'm using the library to build test gcodes (levelling, thin walls, etc.) and I would need this feature.

P.S.: thank you for your great work!